### PR TITLE
integrate vitest with jsdom

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: cd client && yarn run build
 
       - name: Run tests
-        run: cd client && yarn test
+        run: cd client && yarn test:functions

--- a/client/package.json
+++ b/client/package.json
@@ -21,11 +21,12 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@testing-library/react": "^15.0.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.6.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.56.0",
     "eslint-config-standard": "^17.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,7 @@
     "prettier": "npx prettier . --write",
     "check:format": "yarn prettier . --check",
     "test": "vitest",
-    "test:functions": "vitest --include '**/*.ts'"
+    "test:functions": "find . -type f -name '*.ts' | xargs vitest"
   },
   "dependencies": {
     "prettier": "^3.2.5",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "prettier": "npx prettier . --write",
     "check:format": "yarn prettier . --check",
-    "test": "true"
+    "test": "vitest"
   },
   "dependencies": {
     "prettier": "^3.2.5",
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@testing-library/react": "^15.0.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -33,11 +34,13 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "react-router-dom": "^6.22.3",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.7.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "prettier": "npx prettier . --write",
     "check:format": "yarn prettier . --check",
-    "test": "true"
+    "test": "vitest"
   },
   "dependencies": {
     "prettier": "^3.2.5",
@@ -20,11 +20,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@testing-library/react": "^15.0.2",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.6.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.56.0",
     "eslint-config-standard": "^17.1.0",
@@ -33,11 +35,13 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "react-router-dom": "^6.22.3",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.7.0",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "prettier": "npx prettier . --write",
     "check:format": "yarn prettier . --check",
-    "test": "vitest"
+    "test": "vitest",
+    "test:functions": "vitest --include '**/*.ts'"
   },
   "dependencies": {
     "prettier": "^3.2.5",

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,0 +1,18 @@
+// Imports
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// To Test
+import App from '../App';
+
+// Tests
+describe('Renders main page correctly', async () => {
+    it('Should render the page correctly', async () => {
+        // Setup
+        render(<App />);
+        const h1 = await screen.queryByText('Vite + React');
+
+        // Expectations
+        expect(h1).not.toBeNull();
+    });
+});

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import App from '../App';
+
+describe('Renders main page correctly', async () => {
+    it('Should render the page correctly', async () => {
+        // Setup
+        render(<App />);
+        const h1 = await screen.queryByText('Vite + React');
+
+        // Expectations
+        expect(h1).not.toBeNull();
+    });
+});

--- a/client/src/__tests__/App.test.tsx
+++ b/client/src/__tests__/App.test.tsx
@@ -1,11 +1,8 @@
-// Imports
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-// To Test
 import App from '../App';
 
-// Tests
 describe('Renders main page correctly', async () => {
     it('Should render the page correctly', async () => {
         // Setup

--- a/client/src/__tests__/sum.test.ts
+++ b/client/src/__tests__/sum.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { sum } from '../utils/sum'
+
+test('adds 1 + 2 to equal 3', () => {
+    expect(sum(1, 2)).toBe(3)
+})

--- a/client/src/utils/sum.ts
+++ b/client/src/utils/sum.ts
@@ -1,0 +1,3 @@
+export function sum(a: number, b: number){
+    return a + b;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vitest/config';
+import react from "@vitejs/plugin-react-swc";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+    plugins: [react()],
+    test: {
+        // 👋 add the line below to add jsdom to vite
+        environment: 'jsdom',
+    }
 })


### PR DESCRIPTION
There is in fact an issue with testing `.tsx` components inside pipeline.
Pipeline creates Node environment in which we cannot simulate DOM from the get go. 

The solution to that is to use jsdom library.

This works just fine when testing locally, on your own machine. Problem arises when we try to test it in github:action pipeline - the values from queried elements are nullish (when they should not be).

For now, lets just test functions in our pipeline + run tests for DOM elements before pushing the changes.